### PR TITLE
#12 データセットの種類を切り替える機能追加

### DIFF
--- a/app/components/ChartArea/ChartArea.tsx
+++ b/app/components/ChartArea/ChartArea.tsx
@@ -1,4 +1,5 @@
 'use client';
+
 import { usePopulationData } from '@/app/hooks/usePopulationData';
 import { PrefectureContext } from '@/app/utils/context';
 import { useContext, useEffect, useState } from 'react';
@@ -14,7 +15,9 @@ import {
   Legend,
 } from 'chart.js';
 import { Line } from 'react-chartjs-2';
+import { DataTypeSelector } from './DataTypeSelector';
 import '../../styles/components/ChartArea/ChartArea.css';
+import { DataType } from '@/app/utils/types';
 
 ChartJS.register(
   CategoryScale,
@@ -30,14 +33,16 @@ ChartJS.register(
 export const ChartArea = () => {
   const PrefList = useContext(PrefectureContext);
   const [currentPrefList, setCurrentPrefList] = useState(PrefList.prefList);
-  const { updatePrefs, populationData } = usePopulationData(PrefList.prefList);
+  const { targetDatasets, updatePrefs, updateTargetDataIndex } = usePopulationData(
+    PrefList.prefList,
+  );
 
   useEffect(() => {
     updatePrefs(currentPrefList);
     setCurrentPrefList(PrefList.prefList);
   }, [PrefList.prefList]);
 
-  const prefDataSets = populationData.map((data) => {
+  const prefDataSets = targetDatasets.map((data) => {
     return {
       label: `${data.prefCode}.${data.prefName}`,
       data: data.populationData[0].data.map((data) => {
@@ -46,7 +51,7 @@ export const ChartArea = () => {
     };
   });
 
-  const prefDataLabels = populationData[0]?.populationData[0].data.map((data) => {
+  const prefDataLabels = targetDatasets[0]?.populationData[0].data.map((data) => {
     return data.year;
   });
 
@@ -67,16 +72,26 @@ export const ChartArea = () => {
       },
       title: {
         display: true,
-        text: '都道府県別人口構成グラフ',
+        text: targetDatasets[0]?.populationData[0].label ?? DataType.TotalPopulation,
       },
     },
   };
 
   return (
-    <div className="ChartArea">
-      {populationData.length !== 0 && (
-        <Line data={data} options={options} width={900} height={450} />
-      )}
-    </div>
+    <>
+      <div className="ChartArea">
+        {targetDatasets.length !== 0 && (
+          <Line data={data} options={options} width={900} height={450} />
+        )}
+      </div>
+      <DataTypeSelector
+        dataType={targetDatasets[0]?.populationData[0].label ?? DataType.TotalPopulation}
+        onSelectDataType={(dataType) => {
+          dataType !== targetDatasets[0]?.populationData[0].label &&
+            updateTargetDataIndex(dataType);
+        }}
+        isChartEmpty={targetDatasets.length === 0}
+      />
+    </>
   );
 };

--- a/app/components/ChartArea/DataTypeSelector.tsx
+++ b/app/components/ChartArea/DataTypeSelector.tsx
@@ -1,0 +1,24 @@
+'use client';
+
+import { DataType } from '@/app/utils/types';
+import '../../styles/components/ChartArea/DataTypeSelector.css';
+
+type Props = {
+  dataType: DataType;
+  onSelectDataType: (dataType: DataType) => void;
+  isChartEmpty: boolean;
+};
+
+export const DataTypeSelector = (props: Props) => {
+  if (props.isChartEmpty) return <></>;
+  return (
+    <div className="DataTypeSelector">
+      {Object.values(DataType).map((dataType, i) => (
+        <label key={i} onClick={() => props.onSelectDataType(dataType)}>
+          <input type="checkbox" checked={props.dataType === dataType} />
+          <p>{dataType}</p>
+        </label>
+      ))}
+    </div>
+  );
+};

--- a/app/hooks/usePopulationData.ts
+++ b/app/hooks/usePopulationData.ts
@@ -1,9 +1,25 @@
-import { useState } from 'react';
-import { PopulationComparison, PopulationData, Prefecture } from '../utils/types';
+import { useEffect, useState } from 'react';
 import axios from 'axios';
+import { getIndex } from '../utils/helper/getIndex';
+import { DataType, PopulationComparison, PopulationData, Prefecture } from '../utils/types';
 
 export const usePopulationData = (latestPrefList: Prefecture[]) => {
   const [populationData, setPopulationData] = useState<PopulationComparison[]>([]);
+  const [targetDataIndex, setTargetDataIndex] = useState<number>(0);
+  const [targetDatasets, setTargetDatasets] = useState<PopulationComparison[]>([]);
+
+  useEffect(() => {
+    if (populationData.length === 0) return;
+    setTargetDatasets(
+      populationData.map((populationComp) => {
+        return {
+          prefCode: populationComp.prefCode,
+          prefName: populationComp.prefName,
+          populationData: [populationComp.populationData[targetDataIndex]],
+        };
+      }),
+    );
+  }, [populationData, targetDataIndex]);
 
   const updatePrefs = async (newPrefList: Prefecture[]) => {
     if (newPrefList.length < latestPrefList.length) {
@@ -40,8 +56,11 @@ export const usePopulationData = (latestPrefList: Prefecture[]) => {
     }
   };
 
-  // データの追加・削除を行った後、描画用のデータを返す
-  // 描画用データを変更する
+  const updateTargetDataIndex = (dataType: DataType) => {
+    const index = getIndex(dataType);
 
-  return { updatePrefs, populationData };
+    setTargetDataIndex(index);
+  };
+
+  return { targetDatasets, updatePrefs, updateTargetDataIndex };
 };

--- a/app/styles/components/ChartArea/DataTypeSelector.css
+++ b/app/styles/components/ChartArea/DataTypeSelector.css
@@ -1,0 +1,9 @@
+.DataTypeSelector {
+  display: flex;
+  justify-content: center;
+}
+
+.DataTypeSelector label {
+  display: flex;
+  margin: 0 0.5rem;
+}

--- a/app/utils/helper/getIndex.ts
+++ b/app/utils/helper/getIndex.ts
@@ -1,0 +1,16 @@
+import { DataType } from '../types';
+
+export const getIndex = (dataType: DataType) => {
+  switch (dataType) {
+    case DataType.TotalPopulation:
+      return 0;
+    case DataType.YoungPopulation:
+      return 1;
+    case DataType.WorkingAgePopulation:
+      return 2;
+    case DataType.ElderlyPopulation:
+      return 3;
+    default:
+      return 0;
+  }
+};

--- a/app/utils/types.ts
+++ b/app/utils/types.ts
@@ -10,9 +10,16 @@ export type PopulationComparison = {
 };
 
 export type PopulationData = {
-  label: string;
+  label: DataType;
   data: {
     year: number;
     value: number;
   }[];
 };
+
+export enum DataType {
+  TotalPopulation = '総人口',
+  YoungPopulation = '年少人口',
+  WorkingAgePopulation = '生産年齢人口',
+  ElderlyPopulation = '老年人口',
+}


### PR DESCRIPTION
UI
- 総人口、年少人口、生産年齢人口、老年人口を切り替えられるdropdown

func
- hooksで現在populationデータとして返しているものを切り替えるコードをapiデータ取得のhooksに盛り込む
  - ~~人口データ配列の何番目を描画するかのindexと、それを更新する関数をhooksから返す←(これはそこまで複雑じゃないけど、ロジックがフロントにある感じが気になる)~~
  - 人口データの配列から一つ返す形にhooksを修正する
